### PR TITLE
Added support for providing the name while publishing the assessment to ASE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ ounce:publishASE<br>
       client is not on the path
       Expression: ${ounce.installDir}
 
+    name
+      This is the name that the assessment will be saved as in the Enterprise Console.
+      Expression: ${ounce.name}
+
     pathVariableMap
       Map of Ounce variable names and paths.
       pathVariableMap variables are automatically registered with Ounce by the

--- a/src/main/java/org/codehaus/mojo/ounce/PublishASEMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/PublishASEMojo.java
@@ -1,6 +1,6 @@
 /**
  * (c) Copyright IBM Corporation 2016.
- * (c) Copyright HCL Technologies Ltd. 2017. 
+ * (c) Copyright HCL Technologies Ltd. 2019. 
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -33,6 +33,14 @@ public class PublishASEMojo extends AbstractOunceMojo {
 	 */
 	
 	String aseApplication;
+	
+	/**
+	 * This is the name that the assessment will be saved as in the Enterprise Console.
+	 *
+	 * @parameter expression="${ounce.name}"
+	 */
+	
+	String name;
 	
 	/**
 	 * This is the assessment file that will be published to AppScan Enterprise
@@ -88,7 +96,7 @@ public class PublishASEMojo extends AbstractOunceMojo {
 		try
 		{
 			OunceCore core = getCore();
-			core.publishASE(aseApplication, assessmentOutput, caller, folderID, installDir, waitForScan, getLog());
+			core.publishASE(aseApplication, name, assessmentOutput, caller, folderID, installDir, waitForScan, getLog());
 		}
 		catch(Exception ex)
 		{

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCore.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCore.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007, Ounce Labs, Inc.
  * All rights reserved.
- * (c) Copyright HCL Technologies Ltd. 2017. All rights reserved.
+ * (c) Copyright HCL Technologies Ltd. 2019. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -109,7 +109,20 @@ public interface OunceCore
                boolean includeTraceCoverage, String appserver_type, Log log )
         throws OunceCoreException;
     
-    void publishASE(String aseApplication, String assessmentFile, String caller, String folderID,
+    /**
+     * Publishes the assessment file to the AppScan Enterprise Server.
+     * @param aseApplication Enterprise Console application to associate the assessment with. 
+     * @param nameToPublish Name that the assessment will be saved as in the Enterprise Console. If this argument is empty or null, a name will be
+     * generated based on the AppScan Source application that was scanned to produce the assessment (this name will be prepended with AppScan Source:).
+     * @param assessmentFile Path and file name of the assessment file.
+     * @param caller A name to use for auditing purposes.
+     * @param folderID ID of the target assessment.
+     * @param installDir location of ounce client
+     * @param wait if the client should wait for the scan to complete before returning.
+     * @param log
+     * @throws OunceCoreException
+     */
+    void publishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller, String folderID,
     		String installDir, boolean wait, Log log) throws OunceCoreException;
 
     /**

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreConsole.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreConsole.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007, Ounce Labs, Inc.
  * All rights reserved.
- * (c) Copyright HCL Technologies Ltd. 2017. All rights reserved.
+ * (c) Copyright HCL Technologies Ltd. 2019. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -147,9 +147,10 @@ public class OunceCoreConsole
         log.info( "Create Path Variables: Method not supported." );
     }
 
-	public void publishASE(String aseApplication, String assessmentFile, String caller,
+	public void publishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller,
 			String folderID,String installDir, boolean wait, Log log) throws OunceCoreException {
 		log.info("ASE Application: " + aseApplication);
+		log.info("Name To Publish: " + nameToPublish);
 		log.info("Assessment File: " + assessmentFile);
 		log.info("Caller: " + caller);
 		log.info("Folder ID: " + folderID);

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCorePublishASE.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCorePublishASE.java
@@ -3,16 +3,18 @@ package org.codehaus.mojo.ounce.core;
 public class OunceCorePublishASE {
 	
 	private final String assessmentFile;
+	private final String nameToPublish;
 	private final String caller;
 	private final String folderID;
 	private final String installDir;
 	private final String aseApplication;
 	boolean wait;
 	
-	public OunceCorePublishASE(String aseApplication, String assessmentFile, String caller,
+	public OunceCorePublishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller,
 			String folderID, String installDir, boolean wait) {
 		super();
 		this.aseApplication = aseApplication;
+		this.nameToPublish = nameToPublish;
 		this.assessmentFile = assessmentFile;
 		this.caller = caller;
 		this.folderID = folderID;
@@ -23,12 +25,15 @@ public class OunceCorePublishASE {
 	public String getAssessmentFile() {
 		return assessmentFile;
 	}
+	
 	public String getCaller() {
 		return caller;
 	}
+	
 	public String getFolderID() {
 		return folderID;
 	}
+	
 	public String getInstallDir() {
 		return installDir;
 	}
@@ -39,6 +44,10 @@ public class OunceCorePublishASE {
 
 	public String getAseApplication() {
 		return aseApplication;
+	}
+
+	public String getNameToPublish() {
+		return nameToPublish;
 	}
 
 }

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXml.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXml.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007, Ounce Labs, Inc.
  * All rights reserved.
- * (c) Copyright HCL Technologies Ltd. 2017. All rights reserved.
+ * (c) Copyright HCL Technologies Ltd. 2019. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -260,10 +260,10 @@ public class OunceCoreXml
 
     }
 
-	public void publishASE(String aseApplication, String assessmentFile, String caller,
+	public void publishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller,
 			String folderID, String installDir, boolean wait, Log log)
 			throws OunceCoreException {
-		OunceCorePublishASE pub = new OunceCorePublishASE(aseApplication, assessmentFile, caller, folderID, installDir, wait);
+		OunceCorePublishASE pub = new OunceCorePublishASE(aseApplication, nameToPublish, assessmentFile, caller, folderID, installDir, wait);
 		{
 			XStream xs = new XStream();
 			xs.alias( "pub", OunceCorePublishASE.class );

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXmlSerializer.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXmlSerializer.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007, Ounce Labs, Inc.
  * All rights reserved.
- * (c) Copyright HCL Technologies Ltd. 2017. All rights reserved.
+ * (c) Copyright HCL Technologies Ltd. 2019. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -1041,7 +1041,7 @@ public class OunceCoreXmlSerializer implements OunceCore
         return p.waitFor();
     }
 
-	public void publishASE(String aseApplication, String assessmentFile, String caller,
+	public void publishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller,
 			String folderID, String installDir, boolean wait, Log log)
 			throws OunceCoreException {
 		
@@ -1063,7 +1063,12 @@ public class OunceCoreXmlSerializer implements OunceCore
 			{
 				command += String.format(" -aseapplication \"%s\"",aseApplication);
 			}
-			
+
+			if(!StringUtils.isEmpty(nameToPublish))
+			{
+				command += String.format(" -name \"%s\"",nameToPublish);
+			}
+
 			if(!StringUtils.isEmpty(assessmentFile))
 			{
 				command += String.format(" -file \"%s\"", assessmentFile);

--- a/src/test/java/org/codehaus/mojo/ounce/TestUtils/OunceCoreMock.java
+++ b/src/test/java/org/codehaus/mojo/ounce/TestUtils/OunceCoreMock.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007, Ounce Labs, Inc.
  * All rights reserved.
- * (c) Copyright HCL Technologies Ltd. 2017. All rights reserved.
+ * (c) Copyright HCL Technologies Ltd. 2019. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -183,11 +183,11 @@ public class OunceCoreMock
 
     }
 
-	public void publishASE(String aseApplication, String assessmentFile, String caller,
+	public void publishASE(String aseApplication, String nameToPublish, String assessmentFile, String caller,
 			String folderID, String installDir, boolean wait, Log log)
 			throws OunceCoreException {
 		
-		publish = new OunceCorePublishASE(aseApplication, assessmentFile, caller, folderID, installDir, wait);
+		publish = new OunceCorePublishASE(aseApplication, nameToPublish, assessmentFile, caller, folderID, installDir, wait);
 		
 	}
 }


### PR DESCRIPTION
Added support for providing the name while publishing the assessment to ASE, such that the published assessment shall have the given name.

    name
      This is the name that the assessment will be saved as in the Enterprise Console.
      Expression: ${ounce.name}